### PR TITLE
Fix max_packet_size

### DIFF
--- a/facedancer/USBEndpoint.py
+++ b/facedancer/USBEndpoint.py
@@ -102,8 +102,8 @@ class USBEndpoint(USBDescribable):
                 5,          # descriptor type 5 == endpoint
                 address,
                 attributes,
-                self.max_packet_size & 0xff,
                 (self.max_packet_size >> 8) & 0xff,
+                self.max_packet_size & 0xff,
                 self.interval
         ])
 


### PR DESCRIPTION
Max Packet size is being sent wrong on configuration request, thus emulated devices will fail under Windows and MAC. This fix sorts out that issue :)